### PR TITLE
use a specific version (1.25.5) of Docker Compose as the base image f…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker/compose
+FROM docker/compose:1.25.5
 COPY pico /
 ENTRYPOINT ["/pico"]


### PR DESCRIPTION
The `latest` tag for compose is utterly broken.