### PR TITLE
v1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker/compose
+FROM docker/compose:1.25.5
 COPY pico /
 ENTRYPOINT ["/pico"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker/compose:1.25.5
+FROM docker/compose:1.25.1
 COPY pico /
 ENTRYPOINT ["/pico"]


### PR DESCRIPTION
- Better error handling for Git errors during setup, this fixes an error where in certain circumstances errors would be lost and go unreported which would result in what appears to be a deadlock.
- The Pico Docker image now uses a specific Compose version (1.25.5) instead of the latest version available at build-time to prevent unexpected problems.