### PR TITLE
added a "wait status" debug tool

### DIFF
--- a/reconfigurer/git.go
+++ b/reconfigurer/git.go
@@ -126,13 +126,18 @@ func (p *GitProvider) watchConfig() (err error) {
 	}()
 	zap.L().Debug("created new config watcher, awaiting setup")
 
+	err = p.__waitpoint__watch_config(errs)
+
+	zap.L().Debug("config watcher initialised")
+
+	return
+}
+
+func (p *GitProvider) __waitpoint__watch_config(errs chan error) (err error) {
 	select {
 	case <-p.configWatcher.InitialDone:
 	case err = <-errs:
 	}
-
-	zap.L().Debug("config watcher initialised")
-
 	return
 }
 


### PR DESCRIPTION
This uses a special function name signature pattern to identify points in the code that are waiting for significant events such as reconfigure and initial clones. These points are logged when the program recieves an interrupt signal.

For example, if Pico was hanging while initialising, you'd see this after the stack trace:

```
Code that was waiting:
  - start_wait_init
```

This is much easier to read for a user not familiar with Go, the codebase or stack traces. The information is available in the stack trace above, but requires knowledge of the codebase to identify function names and file paths.